### PR TITLE
fix: keep keepVisible when joinZeroWidthSpace:true

### DIFF
--- a/extended_text/src/main/ets/painting/TextSpan.ets
+++ b/extended_text/src/main/ets/painting/TextSpan.ets
@@ -127,7 +127,7 @@ export class TextSpan extends InlineSpan {
         style: this.style,
         actualText: actualText,
         start: start,
-
+        keepVisible: this.keepVisible
       }
     );
   }

--- a/extended_text/src/main/ets/painting/WidgetSpan.ets
+++ b/extended_text/src/main/ets/painting/WidgetSpan.ets
@@ -80,6 +80,7 @@ export class WidgetSpan extends PlaceholderSpan implements WidgetBuilder {
       start: this.start,
       style: this.style,
       actualText: this.actualText,
+      keepVisible: this.keepVisible
     });
   }
 


### PR DESCRIPTION
在joinChar构造新实例时，传递原有的keepVisible
fixed #4 